### PR TITLE
Fix typo in 'toArray'

### DIFF
--- a/to-array.js
+++ b/to-array.js
@@ -4,7 +4,7 @@ function toArray(object) {
   }
   var arr = []
   for (var j = 0; j < (object || []).length; j += 1) {
-    arr.push(object[j]))
+    arr.push(object[j])
   }
   return arr
 }


### PR DESCRIPTION
Removed extra parenthesis, to fix broken builds in development environment. I guess this will require version bumps in other repos.

<details>
<summary>Stack trace</summary>

```
error Error while building ./commands.ts
./node_modules/sketch-utils/to-array.js
Module parse failed: Unexpected token (7:23)
You may need an appropriate loader to handle this file type.
|   var arr = []
|   for (var j = 0; j < (object || []).length; j += 1) {
|     arr.push(object[j]))
|   }
|   return arr
 @ ./node_modules/sketch-utils/index.js 3:25-46
 @ ./node_modules/sketch-polyfill-console/lib/index.js
 @ ./src/common/logger.ts
 @ ./src/common/utils.ts
 @ ./src/commands.ts
```

</details>